### PR TITLE
Widget doesn't render

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -67,7 +67,7 @@ class Menu extends Widget
 
     public function run()
     {
-        $this->widget->run();
+        return $this->widget->run();
     }
 
     private function generateMenuItems()


### PR DESCRIPTION
<?= \yiidreamteam\wizard\Menu::widget(); ?> returns empty string.
My Yii version is 2.0.8-dev.
